### PR TITLE
Verificar y capturar cambios en Sandbox con el trigger

### DIFF
--- a/force-app/main/default/triggers/LanguageCourseTrigger.trigger
+++ b/force-app/main/default/triggers/LanguageCourseTrigger.trigger
@@ -1,0 +1,6 @@
+trigger LanguageCourseTrigger on Language_Course_Instructor__c (after insert, after update, after delete) {
+    for (Language_Course_Instructor__c instructor : Trigger.new) {
+        System.debug('Nuevo o actualizado instructor: ' + instructor.Name);
+        // Aquí puedes agregar código para enviar una notificación u otra acción
+    }
+}

--- a/force-app/main/default/triggers/LanguageCourseTrigger.trigger-meta.xml
+++ b/force-app/main/default/triggers/LanguageCourseTrigger.trigger-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexTrigger xmlns="http://soap.sforce.com/2006/04/metadata">
+  <apiVersion>62.0</apiVersion>
+  <status>Active</status>
+</ApexTrigger>

--- a/force-app/main/default/triggers/TestLanguageCourseTrigger.cls
+++ b/force-app/main/default/triggers/TestLanguageCourseTrigger.cls
@@ -1,0 +1,5 @@
+public with sharing class TestLanguageCourseTrigger {
+    public TestLanguageCourseTrigger() {
+
+    }
+}

--- a/force-app/main/default/triggers/TestLanguageCourseTrigger.cls-meta.xml
+++ b/force-app/main/default/triggers/TestLanguageCourseTrigger.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Se adicionó accionador para el registro de instructores desde el entorno de Sandbox y se probó en la consola de desarrollo.